### PR TITLE
Fix site on some mobile browsers

### DIFF
--- a/webassets/scripts.js
+++ b/webassets/scripts.js
@@ -57,10 +57,10 @@ function createItalicized(text) {
 function artistContactInfo(artist, displayRawLink, defaultToName) {
     try {
         let [name, discordID, contact] = artist;
-        // Convert from undefined to ""
-        name ||= "";
-        discordID ||= "";
-        contact ||= "";
+        // Convert from undefined to "" (note: `||=` is unsupported on some mobile browsers)
+        name = name || "";
+        discordID = discordID || "";
+        contact = contact || "";
 
         if (!name) {
             return document.createTextNode("Discord ID: " + discordID);


### PR DESCRIPTION
Not all mobile browsers support the JS or-assignment operator (`||=`). Use the longer-form syntax (`x = x || <default>`) instead.